### PR TITLE
Randomize on reset fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ dmypy.json
 
 # Output files
 nohup.out
+
+# .idea
+.idea/

--- a/or_gym/utils.py
+++ b/or_gym/utils.py
@@ -4,7 +4,6 @@ def assign_env_config(self, kwargs):
     for key, value in kwargs.items():
         setattr(self, key, value)
     if hasattr(self, 'env_config'):
-        # print(self.env_config)
         for key, value in self.env_config.items():
             # Check types based on default settings
             if hasattr(self, key):
@@ -14,8 +13,8 @@ def assign_env_config(self, kwargs):
                     setattr(self, key,
                         type(getattr(self, key))(value))
             else:
-                setattr(self, key, value)
-                
+                raise AttributeError(f"{self} has no attribute, {key}")
+
 # Get Ray to work with gym registry
 def create_env(config, *args, **kwargs):
 	if type(config) == dict:

--- a/or_gym/version.py
+++ b/or_gym/version.py
@@ -1,6 +1,6 @@
 VERSION='0.2.0'
 
-ENV_LIST = ['Knapsack-v0', 'Knapsack-v1', 'Knapsack-v2',
+ENV_LIST = ['Knapsack-v0', 'Knapsack-v1', 'Knapsack-v2', 'Knapsack-v3',
             'BinPacking-v0', 'BinPacking-v1', 'BinPacking-v2',
             'BinPacking-v3', 'BinPacking-v4', 'BinPacking-v5',
             'VMPacking-v0',


### PR DESCRIPTION
I noticed that only the knapsack-v0 environment had the randomize_on_reset attribute implemented on reset.
I added this to the other knapsack environments.

```python
env = or_gym.make('Knapsack-vX', env_config={'randomize_params_on_reset': True})
```

**Also in this PR:**
- Add .idea/ to .gitignore
- Remove redundant print comment in utils | assign_env_config()
- Promote the use of local variables instead of adding class attributes by raising an attribute error if a parameter in env_config is not a default attribute.
- Add Knapsack-v3 to the ENV_LIST in version.py