### PR TITLE
Fix upper version number for gym to avoid breaking changes in 0.22.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(name='or-gym',
 	packages=find_packages(),
 	install_requires=[
 		'gym>=0.15.0',
+                'gym<=0.21.0',
 		'numpy>=1.16.1',
 		'scipy>=1.0',
 		'matplotlib>=3.1',


### PR DESCRIPTION
`gym>=0.22.0` yields the following error:

```
ImportError: cannot import name 'GoalEnv' from 'gym.core' ($USER/miniconda3/envs/or-gym/lib/python3.8/site-packages/gym/core.py)
```

Adding `gym<=0.21.0` in setup.py will give users a hint to avoid this.